### PR TITLE
Add Typescript as required programming language

### DIFF
--- a/it/pagopa-spa/societa-trasparente/selezione-del-personale/reclutamento-del-personale/lavora-con-noi/JuniorSoftwareEng_mag2021.md
+++ b/it/pagopa-spa/societa-trasparente/selezione-del-personale/reclutamento-del-personale/lavora-con-noi/JuniorSoftwareEng_mag2021.md
@@ -38,8 +38,8 @@ Come _Junior Software Engineer_ le tue principali responsabilità includono :
 - massimo 3 anni di comprovata esperienza relativamente a:
     - Networking: TPC/IP, HTTP
     - OS: Linux
-    - Linguaggi: (almeno uno fra) Java, Kotlin, Scala, Swift, Rust
-    - Scripting: (almeno uno fra) Bash, Python, JavaScript
+    - Linguaggi: (almeno uno fra) Java, Kotlin, Scala, Swift, Rust, Javascript/Typescript
+    - Scripting: (almeno uno fra) Bash, Python
     - Coding: algoritmi, strutture dati , OOD
     - Datastores: RDBMS
 - forte base accademica;

--- a/it/pagopa-spa/societa-trasparente/selezione-del-personale/reclutamento-del-personale/lavora-con-noi/SoftwareEng_mag2021.md
+++ b/it/pagopa-spa/societa-trasparente/selezione-del-personale/reclutamento-del-personale/lavora-con-noi/SoftwareEng_mag2021.md
@@ -39,8 +39,8 @@ Come _Software Engineer_ le tue principali responsabilità includono :
     - Networking: HTTP, REST
     - OS: Linux
     - Virtualisation: Docker, K8s
-    - Linguaggi: (almeno uno fra) Java, Kotlin, Scala, Swift, Rust
-    - Scripting: (almeno uno fra) Bash, Python, JavaScript
+    - Linguaggi: (almeno uno fra) Java, Kotlin, Scala, Swift, Rust, Javascript/Typescript
+    - Scripting: (almeno uno fra) Bash, Python
     - Design: micro-servizi, DDD
     - Coding: algoritmi, strutture dati , OOD
     - Datastores: object-stores, KV stores, RDBMS

--- a/it/pagopa-spa/societa-trasparente/selezione-del-personale/reclutamento-del-personale/lavora-con-noi/SrSoftwareEng_mag2021.md
+++ b/it/pagopa-spa/societa-trasparente/selezione-del-personale/reclutamento-del-personale/lavora-con-noi/SrSoftwareEng_mag2021.md
@@ -38,8 +38,8 @@ Come _Senior Software Engineer_ le tue principali responsabilità includono:
   * Networking: TPC/IP, routing, segmentazione di reti, firewalls, HTTP, REST
   - OS: Linux
   - Virtualisation: Docker, K8s
-  - Linguaggi: (almeno uno fra) Java, Kotlin, Scala, Swift, Rust
-  - Scripting: (almeno uno fra) Bash, Python, JavaScript
+  - Linguaggi: (almeno uno fra) Java, Kotlin, Scala, Swift, Rust, Javascript/Typescript
+  - Scripting: (almeno uno fra) Bash, Python
   - Design: sistemi distribuiti, micro-servizi, DDD
   - Coding: algoritmi, strutture dati , OOD
   - Datastores: object-stores, KV stores, RDBMS


### PR DESCRIPTION
As most of our codebase is actually written in Typescript, I thought it would make sense to name in alongside other suggested languages. 

Also, as Javascript is used by our teams to run production services, I'd rather promote it into languages.