### PR TITLE
[GOV-242] typo redirect_to in redirect.html layout

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -7,7 +7,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no">
     <meta name="robots" content=" noindex, nofollow">
-    <meta http-equiv="refresh" content="0;url={{page.redirect_to}}">
+    <meta http-equiv="refresh" content="0;url={{page.redirect.to}}">
     <title>
         {%- if page.title -%}
         {{ page.title | smartify }} – {{ site.name }}


### PR DESCRIPTION
## Description
Fixed a typo (page.redirect_to -> page.redirect.to) inside the redirect.html layout file causing client-side redirects to malfunction

Fixes # [GOV-242](https://pagopa.atlassian.net/browse/GOV-242)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)



[GOV-242]: https://pagopa.atlassian.net/browse/GOV-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ