### PR TITLE
[GOV-254] Add SEND link to the header section

### DIFF
--- a/_data/t.yml
+++ b/_data/t.yml
@@ -129,6 +129,9 @@ topright-links:
     io:
       name: "IO"
       url: "https://io.italia.it/"
+    send:
+      name: "SEND"
+      url: "https://notifichedigitali.pagopa.it/"
 navigation:
   en:
   it:


### PR DESCRIPTION
Add a link to SEND in the top header section, as here below highlighted:

<img width="1336" alt="Screenshot 2024-03-07 at 14 06 51" src="https://github.com/pagopa/site-pagopa.gov.it/assets/1006711/84252943-03e5-4643-a0fd-73ba8671d630">
