### PR TITLE
Update psp-servizi.html

### DIFF
--- a/_includes/psp-servizi.html
+++ b/_includes/psp-servizi.html
@@ -38,21 +38,20 @@
         {% endfor %}
 
         {% if page.url_informazioni_psp != nil %}
-          <div class="it-right-zone border-bottom border-light mb-4 mt-5" id="convenzioni">
+          <div class="it-right-zone border-bottom border-light mb-4 mt-5" id="trasparenza">
             <span class="text">
-              <h4>Convenzioni</h4>
+              <h4>Trasparenza</h4>
             </span>
           </div>
           <ul class="it-list">
           <li class="it-right-zone mb-4 row">
             <span class="text col-12 col-lg-10 mb-2">
-              {{ page.title }} può applicare costi differenti in caso di
-              convenzioni.
+              Consulta i documenti di trasparenza forniti da {{ page.title }}
             </span>
             <a href="{{ page.url_informazioni_psp }}"
               class="component-posts__item__readmore read-more col-12 col-xl-2 text-lg-right justify-content-xl-end"
-              style="font-weight: 600" title="Scopri le convenzioni">
-              SCOPRI DI PIÙ &rarr;
+              style="font-weight: 600" title="Apri documenti">
+              APRI DOCUMENTI &rarr;
             </a>
           </li>
         </ul>
@@ -97,7 +96,7 @@
               </li>
               {% endfor %} {% if page.url_informazioni_psp != nil %}
               <li>
-                <a class="list-item medium" href="#convenzioni"><span>Convenzioni</span></a>
+                <a class="list-item medium" href="#trasparenza"><span>Trasparenza</span></a>
               </li>
               {% endif %}
             </ul>


### PR DESCRIPTION
This PR updates copy in the PSP detail page, showing a new section called "Trasparenza", a new description and a new CTA.

How to test it:

1. Open any PSP detail page from the available PSP list
2. Scroll to the bottom of the page and check the new title, description and CTA
3. Check the aside link too